### PR TITLE
Add a factory function for Garages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,11 +40,9 @@ TL;DR
 
     # Create a new garage to manage your sample data storage
     GARAGE = garage.create(
-        # Folder where the data will be stored. We'll join lists and expand users HOME
-        # directories (~) for you. If None, uses the default cache folder for your OS.
-        path=["~", ".mypackage", "data"],
-        # An environment variable that overwrites path of the garage.
-        env_variable="MYPACKAGE_DATA_DIR",
+        # Folder where the data will be stored. For a sensible default, use the default
+        # cache folder for your OS.
+        path=garage.os_cache("mypackage"),
         # Base URL of the remote data store. Will call .format on this string to insert
         # the version (see below).
         base_url="https://github.com/myproject/mypackage/raw/{version}/data/",
@@ -55,6 +53,8 @@ TL;DR
         # If a version as a "+XX.XXXXX" suffix, we'll assume that this is a dev version
         # and replace the version with this string.
         version_dev="master",
+        # An environment variable that overwrites path of the garage.
+        env_variable="MYPACKAGE_DATA_DIR",
         # The cache file registry. A dictionary with all files in this garage. Keys are
         # the file names (relative to *base_url*) and values are their respective SHA256
         # hashes. Files will be downloaded automatically when needed (see

--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ TL;DR
         # and replace the version with this string.
         version_dev="master",
         # An environment variable that overwrites path of the garage.
-        env_variable="MYPACKAGE_DATA_DIR",
+        env="MYPACKAGE_DATA_DIR",
         # The cache file registry. A dictionary with all files in this garage. Keys are
         # the file names (relative to *base_url*) and values are their respective SHA256
         # hashes. Files will be downloaded automatically when needed (see

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -8,6 +8,8 @@ API Reference
 .. autosummary::
    :toctree: generated/
 
+    create
+    os_cache
     Garage
     Garage.fetch
     Garage.load_registry

--- a/garage/__init__.py
+++ b/garage/__init__.py
@@ -4,7 +4,8 @@ The Verde public API.
 from ._version import get_versions as _get_versions
 
 # Import functions/classes to make the API
-from .core import Garage
+from .core import Garage, create
+from .utils import os_cache
 
 
 # Get the version number through versioneer

--- a/garage/core.py
+++ b/garage/core.py
@@ -2,6 +2,7 @@
 Functions to download, verify, and update a sample dataset.
 """
 import os
+from pathlib import Path
 import shutil
 from tempfile import NamedTemporaryFile
 from warnings import warn
@@ -9,6 +10,79 @@ from warnings import warn
 import requests
 
 from .utils import file_hash
+
+
+def create(path, base_url, version, version_dev, env_variable=None, registry=None):
+    """
+    Create a new (versioned) Garage with sensible defaults.
+
+    The Garage will be versioned, meaning that the local storage folder and the base URL
+    depend on the projection version. This is necessary if your users have multiple
+    versions of your library installed (using virtual environments) and you updated the
+    data files between versions. If the Garage was not versioned, every time a user
+    switches environments would trigger a re-download of the data.
+
+    The version string will be appended to the local storage path (for example,
+    ``~/.mygarage/cache/v0.1``) and inserted into the base URL (for example,
+    ``https://github.com/fatiando/garage/raw/v0.1/data``). If the version string
+    contains ``+XX.XXXXX``, it will be interpreted as a development version.
+
+    Parameters
+    ----------
+    path : str or PathLike
+        The path to the local data storage folder. If this is a list or tuple, we'll
+        call :func:`os.path.join` on it. The *version* will be appended to the end of
+        this path. Use :func:`garage.os_cache` for a sensible default.
+    base_url : str
+        Base URL for the remote data source. All requests will be made relative to this
+        URL. The string should have a ``{version}`` formatting mark in it. We will call
+        ``.format(version=version)`` on this string.
+    version : str
+        The version string for your project. Should be PEP440 compatible.
+    version_dev : str
+        The name used for the development version of a project. If your data is hosted
+        on Github (and *base_url* is a Github raw link), then ``"master"`` is a good
+        choice.
+    env_variable : str
+        An environment variable that can be used to overwrite *path*. This allows users
+        to control where they want the data to be stored. We'll append *version* to the
+        end of this value as well.
+    registry : dict
+        A record of the files that exist in this garage. Keys should be the file names
+        and the values should be their SHA256 hashes. Only files in the registry can be
+        fetched from the garage.
+
+    Returns
+    -------
+    garage : :class:`~garage.Garage`
+        The Garage initialized with the given arguments.
+
+    Examples
+    --------
+
+    >>> garage = create(path="mygarage", base_url="http://some.link.com/{version}",
+    ...                 version="v0.1", version_dev="master")
+    >>> print(garage.path.parts)
+    ('mygarage', 'v0.1')
+    >>> print(garage.base_url)
+    http://some.link.com/v0.1
+    >>> print(garage.registry)
+    {}
+    >>> garage = create(path="mygarage", base_url="http://some.link.com/{version}",
+    ...                 version="v0.1+12.do9iwd", version_dev="master")
+    >>> print(garage.path.parts)
+    ('mygarage', 'master')
+    >>> print(garage.base_url)
+    http://some.link.com/master
+
+    """
+    path = Path(path)
+    if registry is None:
+        registry = dict()
+    garage = Garage(path=Path(path, version),
+                    base_url=base_url.format(version=version),
+                    registry=registry)
+    return garage
 
 
 class Garage:
@@ -64,14 +138,14 @@ class Garage:
     """
 
     def __init__(self, path, base_url, registry):
-        self._path = path
+        self.path = path
         self.base_url = base_url
         self.registry = dict(registry)
 
     @property
-    def path(self):
+    def abspath(self):
         "Absolute path to the local garage"
-        return os.path.abspath(self._path)
+        return os.path.abspath(os.path.expanduser(self.path))
 
     def fetch(self, fname):
         """
@@ -97,7 +171,7 @@ class Garage:
         """
         if fname not in self.registry:
             raise ValueError("File '{}' is not in the registry.".format(fname))
-        full_path = os.path.join(self.path, fname)
+        full_path = os.path.join(self.abspath, fname)
         in_garage = os.path.exists(full_path)
         update = in_garage and file_hash(full_path) != self.registry[fname]
         download = not in_garage
@@ -123,7 +197,7 @@ class Garage:
             If the hash of the downloaded file doesn't match the hash in the registry.
 
         """
-        destination = os.path.join(self.path, fname)
+        destination = os.path.join(self.abspath, fname)
         source = "".join([self.base_url, fname])
         if update:
             action = "Updating"
@@ -131,7 +205,7 @@ class Garage:
             action = "Downloading"
         warn(
             "{} data file '{}' from remote data store '{}' to '{}'.".format(
-                action, fname, self.base_url, self.path
+                action, fname, self.base_url, self.abspath
             )
         )
         response = requests.get(source, stream=True)

--- a/garage/core.py
+++ b/garage/core.py
@@ -210,7 +210,7 @@ class Garage:
     @property
     def abspath(self):
         "Absolute path to the local garage"
-        return Path(self.path).expanduser().resolve()
+        return Path(os.path.abspath(os.path.expanduser(self.path)))
 
     def fetch(self, fname):
         """

--- a/garage/tests/test_core.py
+++ b/garage/tests/test_core.py
@@ -9,7 +9,7 @@ import pytest
 
 from .. import Garage
 from ..utils import file_hash
-from .utils import garage_test_url, garage_test_registry
+from .utils import garage_test_url, garage_test_registry, check_tiny_data
 
 
 DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
@@ -27,13 +27,7 @@ def test_garage_local():
     true = os.path.join(DATA_DIR, "tiny-data.txt")
     fname = garage.fetch("tiny-data.txt")
     assert true == fname
-    assert os.path.exists(fname)
-    with open(fname) as tinydata:
-        content = tinydata.read()
-    true_content = "\n".join(
-        ["# A tiny data file for test purposes only", "1  2  3  4  5  6"]
-    )
-    assert content.strip() == true_content
+    check_tiny_data(fname)
 
 
 def test_garage_update():
@@ -55,13 +49,7 @@ def test_garage_update():
             assert str(warn[-1].message).split()[-1] == "'{}'.".format(local_store)
         # Check that the updated file has the right content
         assert true_path == fname
-        assert os.path.exists(fname)
-        with open(fname) as tinydata:
-            content = tinydata.read()
-        true_content = "\n".join(
-            ["# A tiny data file for test purposes only", "1  2  3  4  5  6"]
-        )
-        assert content.strip() == true_content
+        check_tiny_data(fname)
         assert file_hash(fname) == REGISTRY["tiny-data.txt"]
 
 

--- a/garage/tests/test_core.py
+++ b/garage/tests/test_core.py
@@ -33,20 +33,21 @@ def test_garage_local():
 def test_garage_update():
     "Setup a garage that already has the local data but the file is outdated"
     with TemporaryDirectory() as local_store:
+        path = os.path.abspath(os.path.expanduser(local_store))
         # Create a dummy version of tiny-data.txt that is different from the one in the
         # remote storage
-        true_path = os.path.join(local_store, "tiny-data.txt")
+        true_path = os.path.join(path, "tiny-data.txt")
         with open(true_path, "w") as fin:
             fin.write("different data")
         # Setup a garage in a temp dir
-        garage = Garage(path=local_store, base_url=BASEURL, registry=REGISTRY)
+        garage = Garage(path=path, base_url=BASEURL, registry=REGISTRY)
         # Check that the warning says that the file is being updated
         with warnings.catch_warnings(record=True) as warn:
             fname = garage.fetch("tiny-data.txt")
             assert len(warn) == 1
             assert issubclass(warn[-1].category, UserWarning)
             assert str(warn[-1].message).split()[0] == "Updating"
-            assert str(warn[-1].message).split()[-1] == "'{}'.".format(local_store)
+            assert str(warn[-1].message).split()[-1] == "'{}'.".format(path)
         # Check that the updated file has the right content
         assert true_path == fname
         check_tiny_data(fname)
@@ -57,14 +58,15 @@ def test_garage_corrupted():
     "Raise an exception if the hash of downloaded file doesn't match the registry"
     # Test the case where the file wasn't in the directory
     with TemporaryDirectory() as local_store:
-        garage = Garage(path=local_store, base_url=BASEURL, registry=REGISTRY_CORRUPTED)
+        path = os.path.abspath(os.path.expanduser(local_store))
+        garage = Garage(path=path, base_url=BASEURL, registry=REGISTRY_CORRUPTED)
         with warnings.catch_warnings(record=True) as warn:
             with pytest.raises(ValueError):
                 garage.fetch("tiny-data.txt")
             assert len(warn) == 1
             assert issubclass(warn[-1].category, UserWarning)
             assert str(warn[-1].message).split()[0] == "Downloading"
-            assert str(warn[-1].message).split()[-1] == "'{}'.".format(local_store)
+            assert str(warn[-1].message).split()[-1] == "'{}'.".format(path)
     # and the case where the file exists but hash doesn't match
     garage = Garage(path=DATA_DIR, base_url=BASEURL, registry=REGISTRY_CORRUPTED)
     with warnings.catch_warnings(record=True) as warn:

--- a/garage/tests/test_integration.py
+++ b/garage/tests/test_integration.py
@@ -1,0 +1,50 @@
+# pylint: disable=redefined-outer-name
+"""
+Test the entire process of creating a garage and using it.
+"""
+import os
+import shutil
+from pathlib import Path
+import warnings
+
+import pytest
+
+from .. import create, os_cache, __version__
+from .utils import check_tiny_data
+
+
+@pytest.fixture(scope="module")
+def garage():
+    "Create a garage the way most projects would."
+    gar = create(
+        path=os_cache("garage"),
+        base_url="https://github.com/fatiando/garage/raw/{version}/data/",
+        version=__version__,
+        version_dev="master",
+        env="GARAGE_DATA_DIR",
+    )
+    gar.load_registry(Path(os.path.dirname(__file__), "data", "registry.txt"))
+    yield gar
+    shutil.rmtree(gar.abspath)
+
+
+def test_fetch(garage):
+    "Fetch a data file from the garage"
+    # Make sure the garage exists and is empty to begin
+    assert garage.abspath.exists()
+    assert not os.listdir(garage.abspath)
+    with warnings.catch_warnings(record=True) as warn:
+        fname = garage.fetch("tiny-data.txt")
+        assert len(warn) == 1
+        assert issubclass(warn[-1].category, UserWarning)
+        assert str(warn[-1].message).split()[0] == "Downloading"
+    check_tiny_data(fname)
+    # Now modify the file to trigger an update on the next fetch
+    with open(fname, "w") as fin:
+        fin.write("The data is now different")
+    with warnings.catch_warnings(record=True) as warn:
+        fname = garage.fetch("tiny-data.txt")
+        assert len(warn) == 1
+        assert issubclass(warn[-1].category, UserWarning)
+        assert str(warn[-1].message).split()[0] == "Updating"
+    check_tiny_data(fname)

--- a/garage/tests/utils.py
+++ b/garage/tests/utils.py
@@ -1,8 +1,23 @@
 """
 Utilities for testing code.
 """
+import os
+
 from .. import __version__
 from ..utils import check_version
+
+
+def check_tiny_data(fname):
+    """
+    Load the tiny-data.txt file and check that the contents are correct.
+    """
+    assert os.path.exists(fname)
+    with open(fname) as tinydata:
+        content = tinydata.read()
+    true_content = "\n".join(
+        ["# A tiny data file for test purposes only", "1  2  3  4  5  6"]
+    )
+    assert content.strip() == true_content
 
 
 def garage_test_url():

--- a/garage/utils.py
+++ b/garage/utils.py
@@ -1,9 +1,54 @@
 """
 Misc utilities
 """
+from pathlib import Path
+import sys
 import hashlib
 
 from packaging.version import Version
+
+
+def os_cache(project, platform=None):
+    r"""
+    Default cache location based on the operating system.
+
+    Will insert the project name in the proper location of the path.
+
+    Parameters
+    ----------
+    project : str
+        The project name.
+    platform : str or None
+        The name of operating system as returned by ``sys.platform`` (``'darwin'`` for
+        Mac, ``'win32'`` for Windows, and anything else will be treated as generic
+        Linux/Unix. If None, will use the value of ``sys.platform``.
+
+    Returns
+    -------
+    cache_path : :class:`pathlib.Path`
+        The default location for the data cache. User directories (``'~'``) are not
+        expanded.
+
+    Examples
+    --------
+
+    >>> for os in ['darwin', 'win32', 'anything else']:
+    ...     path = os_cache("myproject", platform=os)
+    ...     print(path.parts)
+    ('~', 'Library', 'Caches', 'myproject')
+    ('~', 'AppData', 'Local', 'myproject', 'cache')
+    ('~', '.cache', 'myproject')
+
+    """
+    if platform is None:
+        platform = sys.platform
+    if platform == "darwin":
+        cache_path = Path("~", "Library", "Caches", project)
+    elif platform == "win32":
+        cache_path = Path("~", "AppData", "Local", project, "cache")
+    else:  # *NIX
+        cache_path = Path("~", ".cache", project)
+    return cache_path
 
 
 def file_hash(fname):


### PR DESCRIPTION
Adds the `garage.create` function that instantiates Garages with sensible defaults.
It checks that paths exist and creates the local folder, separates different versions, and enables the use of an environment variable to set the local folder.
The ability to use a default cache folder for the OS is separated into the `garage.os_cache` function.